### PR TITLE
delete review notecards from previous day with each run of cron job

### DIFF
--- a/app/Http/Controllers/MailController.php
+++ b/app/Http/Controllers/MailController.php
@@ -14,6 +14,7 @@ class MailController extends Controller
     public function index()
 {
 
+    Reviewnotecard::where('created_at', '<', now()->startOfDay())->delete();
 
     // Retrieve the notecards for the daily stack
     $notecards = Notecard::getItemsForReview();


### PR DESCRIPTION
- delete review notecards from previous day with each run of cron job. (Was doing this per user when they would load their notecards. This catches users that have not logged in for awhile)